### PR TITLE
add setting to allow additional manage.py commands

### DIFF
--- a/siteprefs/settings.py
+++ b/siteprefs/settings.py
@@ -6,3 +6,7 @@ EXPOSE_MODEL_TO_ADMIN = getattr(settings, 'SITEPREFS_EXPOSE_MODEL_TO_ADMIN', Fal
 
 # Module name used by siteprefs.toolbox.autodiscover_siteprefs() to find preferences in application packages.
 PREFS_MODULE_NAME = getattr(settings, 'SITEPREFS_MODULE_NAME', 'settings')
+
+# List of commands called by manage.py where autodiscover is enabled
+ENABLED_COMMANDS = getattr(settings, "SITEPREFS_ENABLED_COMMANDS",
+                           ['runserver', 'runserver_plus', 'run_gunicorn', 'celeryd'])

--- a/siteprefs/toolbox.py
+++ b/siteprefs/toolbox.py
@@ -8,6 +8,7 @@ from .models import Preference
 from .utils import import_prefs, get_frame_locals, traverse_local_prefs, get_pref_model_admin_class, get_pref_model_class, PrefProxy, PatchedLocal, Frame
 from .exceptions import SitePrefsException
 from .signals import prefs_save
+from .settings import ENABLED_COMMANDS
 
 
 __PATCHED_LOCALS_SENTINEL = '__siteprefs_locals_patched'
@@ -87,7 +88,7 @@ def autodiscover_siteprefs():
 
     UTILS_PACKAGE = 'django.utils'
     # Do not discover anything if called from manage.py (e.g. executing commands from cli).
-    if package != UTILS_PACKAGE or (len(sys.argv) > 1 and sys.argv[1] == 'runserver'):
+    if package != UTILS_PACKAGE or (len(sys.argv) > 1 and sys.argv[1] in ENABLED_COMMANDS):
         import_prefs()
         Preference.read_prefs(get_prefs())
         register_admin_models()


### PR DESCRIPTION
Hit an issue where I was using 'runserver_plus' and took me a while to understand why siteprefs wasn't working.  Django deployments often use manage.py to start production servers such as gunicorn or celeryd.  So, I've added a setting to make the list of enabled commands available to settings.py and made the default the most common suspects.  Thanks!  Brian
