### PR TITLE
implementing __int__() to allow casting PrefProxy to int

### DIFF
--- a/siteprefs/utils.py
+++ b/siteprefs/utils.py
@@ -94,6 +94,9 @@ class PrefProxy(object):
     def __repr__(self):
         return '%s = %s' % (self.name, self.get_value())
 
+    def __int__(self):
+        return int(self.get_value())
+
 
 def get_field_for_proxy(pref_proxy):
     """Returns a field object instance for a given PrefProxy object."""


### PR DESCRIPTION
Please accept my change based on:

If i from setttings import my_var and my my_var was originally an integer value i would like to use it without asking if it's a PrefProxy instance and calling .get_value() on it.

It would be better if could just do int(myvar)

If i'm just using django-siteprefs in the wrong way or there is a better solution just let me know,

thanks.

