### PR TITLE
WIP: Overwrite django.conf

### DIFF
--- a/siteprefs/tests/test_utils.py
+++ b/siteprefs/tests/test_utils.py
@@ -16,6 +16,7 @@ def test_mimic():
 
     assert M(4)() == 4
     assert str(M('www')) == 'www'
+    assert str(M('abc')[1]) == 'b'
     assert len(M('some')) == 4
     assert int(M(4)) == 4
     assert float(M(4.2)) == 4.2

--- a/siteprefs/toolbox.py
+++ b/siteprefs/toolbox.py
@@ -8,7 +8,6 @@ from django.contrib.admin import AdminSite
 from django.db.models import Model, Field
 
 from .exceptions import SitePrefsException
-from .models import Preference
 from .settings import MANAGE_SAFE_COMMANDS
 from .signals import prefs_save
 from .utils import import_prefs, get_frame_locals, traverse_local_prefs, get_pref_model_admin_class, \
@@ -26,6 +25,8 @@ def on_pref_update(*args, **kwargs):
      Issues DB save and reread.
 
     """
+    from .models import Preference
+
     Preference.update_prefs(*args, **kwargs)
     Preference.read_prefs(get_prefs())
 
@@ -162,6 +163,8 @@ def autodiscover_siteprefs(admin_site: AdminSite = None):
     :param admin_site: Custom AdminSite object.
 
     """
+    from .models import Preference
+
     if admin_site is None:
         admin_site = admin.site
 

--- a/siteprefs/toolbox.py
+++ b/siteprefs/toolbox.py
@@ -28,7 +28,9 @@ def on_pref_update(*args, **kwargs):
     from .models import Preference
 
     Preference.update_prefs(*args, **kwargs)
-    Preference.read_prefs(get_prefs())
+    prefs = get_prefs()
+    populate_django_settings(prefs)
+    Preference.read_prefs(prefs)
 
 prefs_save.connect(on_pref_update)
 
@@ -157,6 +159,14 @@ def register_admin_models(admin_site: AdminSite):
             admin_site.register(model_class, get_pref_model_admin_class(prefs_items))
 
 
+def populate_django_settings(mem_prefs: dict):
+    from django.conf import settings
+
+    for app, prefs in mem_prefs.items():
+        for pref_name, pref_proxy in prefs.items():
+            setattr(settings, pref_name.upper(), pref_proxy)
+
+
 def autodiscover_siteprefs(admin_site: AdminSite = None):
     """Automatically discovers and registers all preferences available in all apps.
 
@@ -171,7 +181,9 @@ def autodiscover_siteprefs(admin_site: AdminSite = None):
     # Do not discover anything if called from manage.py (e.g. executing commands from cli).
     if 'manage' not in sys.argv[0] or (len(sys.argv) > 1 and sys.argv[1] in MANAGE_SAFE_COMMANDS):
         import_prefs()
-        Preference.read_prefs(get_prefs())
+        prefs = get_prefs()
+        Preference.read_prefs(prefs)
+        populate_django_settings(prefs)
         register_admin_models(admin_site)
 
 

--- a/siteprefs/utils.py
+++ b/siteprefs/utils.py
@@ -93,6 +93,9 @@ class Mimic:
     def __contains__(self, item):
         return self.value.__contains__(item)
 
+    def __getitem__(self, item):
+        return self.value[item]
+
     def __sub__(self, other):
         return self.value.__sub__(other)
 


### PR DESCRIPTION
Demo for https://github.com/idlesign/django-siteprefs/issues/23

Includes Mimic hackery so that the following works

```py
from django.conf import settings as django_settings
from django.http import JsonResponse

def settings(request):
    return JSONResponse({
        'site_name': django_settings.SITE_NAME,
    })
```